### PR TITLE
Add example(s) to Schema

### DIFF
--- a/openapi_builder/builder.py
+++ b/openapi_builder/builder.py
@@ -20,6 +20,7 @@ from .specification import (
     RequestBody,
     Response,
     Responses,
+    Schema,
     Server,
 )
 from .util import openapi_endpoint_name_from_rule, parse_openapi_arguments
@@ -143,6 +144,7 @@ class OpenAPIBuilder:
                 raise MissingConverter()
             elif self.options.strict_mode == self.options.StrictMode.SHOW_WARNINGS:
                 warnings.warn(f"Missing converter for: {value}", UserWarning)
+                return Schema(example="<unknown>")
             else:
                 raise ValueError(f"Unknown strict mode: {self.options.strict_mode}")
         else:

--- a/openapi_builder/specification.py
+++ b/openapi_builder/specification.py
@@ -1473,6 +1473,8 @@ class Schema:
         description: Optional[str] = None,
         format: Optional[str] = None,
         default: Optional[Any] = None,
+        example: Optional[Any] = None,
+        examples: Optional[Dict[str, Union["Example", Reference]]] = None,
     ):
         self.title: Optional[str] = title
         self.multiple_of: Optional[int] = multiple_of
@@ -1505,6 +1507,8 @@ class Schema:
         self.description: Optional[str] = description
         self.format: Optional[str] = format
         self.default: Optional[Any] = default
+        self.example: Optional[Any] = example
+        self.examples: Optional[Dict[str, Dict[str, Any]]] = examples
 
     def get_value(self):
         value = {}
@@ -1565,6 +1569,10 @@ class Schema:
             value["format"] = self.format
         if self.default is not None:
             value["default"] = self.default
+        if self.example is not None:
+            value["example"] = self.example
+        if self.examples is not None:
+            value["examples"] = self.examples
 
         return value
 


### PR DESCRIPTION
Note: the `return Schema(example="<unknown>")` is temporary to unblock myself until you or I add `register_converter(is_fallback=True)`.