### PR TITLE
Fixed issue with halogen inheritance

### DIFF
--- a/openapi_builder/__meta__.py
+++ b/openapi_builder/__meta__.py
@@ -2,7 +2,7 @@ name = "openapi_builder"
 path = name.lower().replace("-", "_").replace(" ", "_")
 # The version number should follow https://python.org/dev/peps/pep-0440 and
 # https://semver.org
-version = "0.2.8"
+version = "0.2.9"
 author = "Patrick Vogel"
 author_email = "patrickvogel@live.nl"
 description = (

--- a/openapi_builder/converters/schema/halogen.py
+++ b/openapi_builder/converters/schema/halogen.py
@@ -129,7 +129,7 @@ class LinkConverter(SchemaConverter):
     def convert(self, value, name) -> Schema:
         properties = {}
 
-        for prop in value.__class_attrs__.values():
+        for prop in value.__attrs__.values():
             properties[prop.key] = Schema(type="string", format="url", example="<url>")
 
         return Schema(type="object", properties=properties)
@@ -142,8 +142,7 @@ class CurieConverter(SchemaConverter):
 
     def matches(self, value) -> bool:
         return (
-            super().matches(value)
-            and value.__class_attrs__.keys() == self.currie_attributes
+            super().matches(value) and value.__attrs__.keys() == self.currie_attributes
         )
 
     def convert(self, value, name) -> Schema:
@@ -179,7 +178,7 @@ class SchemaConverter(SchemaConverter):
         )
         properties = {}
 
-        for key, prop in value.__class_attrs__.items():
+        for key, prop in value.__attrs__.items():
             if prop.compartment:
                 if prop.compartment not in properties:
                     properties[prop.compartment] = Schema(type="object")


### PR DESCRIPTION
Halogen uses `__attrs__` to iterate over the attributes of a class, including base classes. It uses `__class_attrs__` to iterate over the attributes belonging to this class only.