### PR TITLE
Remove `raise ValueError(f"self.config should be None")`

### DIFF
--- a/openapi_builder/__meta__.py
+++ b/openapi_builder/__meta__.py
@@ -2,7 +2,7 @@ name = "openapi_builder"
 path = name.lower().replace("-", "_").replace(" ", "_")
 # The version number should follow https://python.org/dev/peps/pep-0440 and
 # https://semver.org
-version = "0.2.8"
+version = "0.2.9"
 author = "Patrick Vogel"
 author_email = "patrickvogel@live.nl"
 description = (

--- a/openapi_builder/converters/schema/halogen.py
+++ b/openapi_builder/converters/schema/halogen.py
@@ -129,7 +129,7 @@ class LinkConverter(SchemaConverter):
     def convert(self, value, name) -> Schema:
         properties = {}
 
-        for prop in value.__class_attrs__.values():
+        for prop in value.__attrs__.values():
             properties[prop.key] = Schema(type="string", format="url", example="<url>")
 
         return Schema(type="object", properties=properties)
@@ -142,8 +142,7 @@ class CurieConverter(SchemaConverter):
 
     def matches(self, value) -> bool:
         return (
-            super().matches(value)
-            and value.__class_attrs__.keys() == self.currie_attributes
+            super().matches(value) and value.__attrs__.keys() == self.currie_attributes
         )
 
     def convert(self, value, name) -> Schema:
@@ -179,7 +178,7 @@ class SchemaConverter(SchemaConverter):
         )
         properties = {}
 
-        for key, prop in value.__class_attrs__.items():
+        for key, prop in value.__attrs__.items():
             if prop.compartment:
                 if prop.compartment not in properties:
                     properties[prop.compartment] = Schema(type="object")

--- a/openapi_builder/documentation.py
+++ b/openapi_builder/documentation.py
@@ -66,8 +66,6 @@ class DocumentationConfigManager:
             raise TypeError(
                 f"{documentation_config} is not an instance of Documentation."
             )
-        if self.config is not None:
-            raise ValueError(f"self.config should be None, but is {self.config}")
 
         self.config = documentation_config
         yield


### PR DESCRIPTION
Sometimes self.config on old line 69 is still populated and we don't understand why. Maybe the contextmanager never executes the exit statement after yield? Although we should find the core issue and solve that, for now let's remove the validation because self.config is overwritten anyway, and the ValueError causes apps to be broken.