### PR TITLE
Read Halogen attr docstrings for field descriptions

### DIFF
--- a/openapi_builder/converters/schema/halogen.py
+++ b/openapi_builder/converters/schema/halogen.py
@@ -199,6 +199,8 @@ class SchemaConverter(SchemaConverter):
                 attr.default = self.manager.builder.default_manager.process(
                     prop.default
                 )
+            if prop.__doc__ and prop.__doc__ is not halogen.Attr.__doc__:
+                attr.description = prop.__doc__
             result[prop.key] = attr
 
         schema = Schema(type="object", properties=properties)

--- a/tests/unit/converters/schema/test_halogen.py
+++ b/tests/unit/converters/schema/test_halogen.py
@@ -79,7 +79,9 @@ def test_halogen_description_from_docstring(http, app, open_api_documentation):
     fish_schema = configuration["components"]["schemas"]["Fish"]
     assert fish_schema["type"] == "object"
     assert fish_schema["required"] == ["name"]
-    assert fish_schema["properties"] == {"name": {"type": "string", "description": "Name of this fish."}}
+    assert fish_schema["properties"] == {
+        "name": {"type": "string", "description": "Name of this fish."}
+    }
 
 
 @pytest.mark.usefixtures("get_with_halogen_schema")
@@ -98,6 +100,7 @@ def test_halogen_description_from_docstring_hidden(http, app, open_api_documenta
         def num_fins(value):
             """Docstring explaining an internal implementation detail."""
             return value
+
         num_fins.__doc__ = "Public doc."
 
     @app.route("/fish", methods=["GET"])
@@ -112,4 +115,7 @@ def test_halogen_description_from_docstring_hidden(http, app, open_api_documenta
     fish_schema = configuration["components"]["schemas"]["FishWithSecrets"]
     assert fish_schema["required"] == ["nickname", "num_fins"]
     assert fish_schema["properties"]["nickname"] == {"type": "string"}
-    assert fish_schema["properties"]["num_fins"] == {"type": "string", "description": "Public doc."}
+    assert fish_schema["properties"]["num_fins"] == {
+        "type": "string",
+        "description": "Public doc.",
+    }


### PR DESCRIPTION
In Paylogic we have the convention of adding `"""human description"""` docstrings below Halogen fields, example:

```py
class CreateChangeOrderConfig(halogen.Schema):

    name = halogen.Attr(types.String())
    """Change order config name."""

    include_costs_per_order = halogen.Attr(common_types.Boolean())
    """Whether to include costs per order in the change order amount."""
```

Including these docstrings in our documentation would make it a lot more readable. However we would have to do static code analysis to parse them, I guess that's the reason you're not using them as descriptions? 

If that is indeed the case, we can read them easily if we change the syntax to:

```py
class CreateChangeOrderConfig(halogen.Schema):

    name = halogen.Attr(types.String())
    name.__doc__ = "Change order config name."

    include_costs_per_order = halogen.Attr(common_types.Boolean())
    include_costs_per_order.__doc__ = "Whether to include costs per order in the change order amount."
```

Then we can just read `CreateChangeOrderConfig.name.__doc__`, see changes in this pull request.

What do you think?

---

Context: I was checking whether the Shopping API can start using OpenAPI builder. I think if we start parsing field docstrings, we can switch quite quickly.

 - [Pycharm styles dynamic doc assignments them as docstrings](https://user-images.githubusercontent.com/788368/192035538-b82f261c-5068-4387-af20-08ee69b19fcc.png)
 - [This is how /POST basket looks with descriptions](https://user-images.githubusercontent.com/788368/192036932-5b8f729e-8c59-48ad-9311-9ef551ba9e66.png)
 - [This is how /POST basket looks without descriptions](https://user-images.githubusercontent.com/788368/192037143-a2e7b56f-9071-40f7-9dfd-6759c6b3b957.png)
